### PR TITLE
Updates

### DIFF
--- a/functions/assembly/index.ts
+++ b/functions/assembly/index.ts
@@ -1,7 +1,7 @@
 import { inference } from "@hypermode/functions-as";
 
 export function testClassifier(text: string): string {
-  const modelName = "sentiment_classifier";
+  const modelName = "sentiment-classifier";
   const threshold: f32 = 0.5;
   return inference.classifyText(modelName, text, threshold);
 }

--- a/hypermode.json
+++ b/hypermode.json
@@ -2,7 +2,7 @@
   "$schema": "https://manifest.hypermode.com/hypermode.json",
   "models": [
     {
-      "name": "sentiment_classifier",
+      "name": "sentiment-classifier",
       "task": "classification",
       "sourceModel": "distilbert/distilbert-base-uncased-finetuned-sst-2-english",
       "provider": "hugging-face",

--- a/hypermode.json
+++ b/hypermode.json
@@ -8,12 +8,5 @@
       "provider": "hugging-face",
       "host": "hypermode"
     }
-  ],
-  "hosts": [
-    {
-      "name": "openai",
-      "endpoint": "https://api.openai.com/v1",
-      "authHeader": "x-api-key"
-    }
   ]
 }


### PR DESCRIPTION
- Hyphens are required in model and host names instead of underscores.
- OpenAI isn't used in this template, so it shouldn't be in the manifest.